### PR TITLE
Upload Bee Photo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies: ["flake8-bandit", "flake8-bugbear"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
+
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.23.1
+    hooks:
+      - id: pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         args: ["--profile", "black", "--filter-files"]
 
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/main.py
+++ b/main.py
@@ -16,25 +16,23 @@ def upload_bee_photo(
 ) -> str:
     """
     Upload a bee photo to an S3 bucket
-    - **file_obj**: required, a file like object - hopefully it is a
-    nice bee photo
+    - **file_obj**: required, a file like object - hopefully it is a nice bee photo
     - **bucket**: the S3 bucket to post the file object to
     - **acl**: the S3 access control list type
-    Returns the url of the file you uploaded
+    Returns a dictionary with the url of the file you uploaded as the value of the key
     """
     response = upload_file(file_obj=file_obj, bucket=bucket, acl=acl)
     return {"message": response}
 
 
 def upload_file(
-    file_obj, bucket: Optional[str] = None, acl: Optional[str] = None
+    file_obj: UploadFile, bucket: Optional[str] = None, acl: Optional[str] = None
 ) -> str:
     """Upload a file like object to an S3 bucket
     :param file_obj: File like object recognized by FastAPI
     :param bucket: the S3 bucket to post the file object to
     :param acl: the S3 access control list type
-    :return: dict containing a value with the URL of the file you
-    uploaded
+    :return: dict containing a value with the URL of the file you uploaded
     """
     s3_bucket = bucket or os.environ["AWS_S3_BUCKET"]
 

--- a/main.py
+++ b/main.py
@@ -39,9 +39,11 @@ def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = Non
     s3_client = boto3.client('s3',
             aws_access_key_id = aws_key,
             aws_secret_access_key = aws_secret)
+    
     response = s3_client.upload_fileobj(file_obj.file, s3_bucket, file_obj.filename) 
-
-    return response
+    head = s3_client.head_object(Bucket = s3_bucket, Key = file_obj.filename)
+    success = head['ContentLength']
+    return success
 
 @app.get("/bees/{file_path:path}")
 def fetch_bee_photo(file_path: str):

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
-from fastapi import FastAPI, UploadFile
-import boto3
-from botocore.exceptions import ClientError
 import os
-from dotenv import load_dotenv
 from typing import Optional
+
+import boto3
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, UploadFile
 
 load_dotenv()
 
@@ -11,23 +11,30 @@ app = FastAPI()
 
 
 @app.post("/upload_bee/")
-def upload_bee_photo(file_obj:UploadFile, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
+def upload_bee_photo(
+    file_obj: UploadFile, bucket: Optional[str] = None, acl: Optional[str] = None
+) -> str:
     """
     Upload a bee photo to an S3 bucket
-    - **file_obj**: required, a file like object - hopefully it is a nice bee photo
+    - **file_obj**: required, a file like object - hopefully it is a
+    nice bee photo
     - **bucket**: the S3 bucket to post the file object to
     - **acl**: the S3 access control list type
     Returns the url of the file you uploaded
     """
     response = upload_file(file_obj=file_obj, bucket=bucket, acl=acl)
-    return {"message":response}
+    return {"message": response}
 
-def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
+
+def upload_file(
+    file_obj, bucket: Optional[str] = None, acl: Optional[str] = None
+) -> str:
     """Upload a file like object to an S3 bucket
     :param file_obj: File like object recognized by FastAPI
     :param bucket: the S3 bucket to post the file object to
     :param acl: the S3 access control list type
-    :return: dict containing a value with the URL of the file you uploaded
+    :return: dict containing a value with the URL of the file you
+    uploaded
     """
     s3_bucket = bucket or os.environ["AWS_S3_BUCKET"]
 
@@ -36,28 +43,28 @@ def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = Non
     aws_region = os.environ["AWS_REGION"]
     acl = acl or os.environ["AWS_ACL"]
 
-    s3_client = boto3.client('s3',
-            aws_access_key_id = aws_key,
-            aws_secret_access_key = aws_secret)
-    
+    s3_client = boto3.client(
+        "s3", aws_access_key_id=aws_key, aws_secret_access_key=aws_secret
+    )
+
     response = s3_client.upload_fileobj(file_obj.file, s3_bucket, file_obj.filename)
 
-    head = s3_client.head_object(Bucket = s3_bucket, Key = file_obj.filename)
-    upload_content_length = head['ContentLength']
+    head = s3_client.head_object(Bucket=s3_bucket, Key=file_obj.filename)
+    upload_content_length = head["ContentLength"]
 
-    if upload_content_length > 0:
-        response = f"https://{s3_bucket}.s3.{aws_region}.amazonaws.com/{file_obj.filename}"
-    else:
-        response = f"Something went wrong in upload_fileobj"
-
+    if upload_content_length == 0:
+        raise HTTPException(
+            status_code=500, detail="Something went wrong in the file upload process"
+        )
+    response = f"https://{s3_bucket}.s3.{aws_region}.amazonaws.com/{file_obj.filename}"
     return response
+
 
 @app.get("/bees/{file_path:path}")
 def fetch_bee_photo(file_path: str):
     return {"file_path": file_path}
 
+
 @app.delete("/bees/{file_path:path}")
 def delete_bee_photo(file_path: str):
     return {"file_path": file_path}
-
-

--- a/main.py
+++ b/main.py
@@ -10,7 +10,13 @@ load_dotenv()
 app = FastAPI()
 
 
+##TODO: Build out the fast api function placeholder so it is separate from the upload_file function
 @app.post("/upload_bee/")
+def placeholder():
+    response.key = upload_file()
+    return {"message":s3_file_link}
+
+
 def upload_file(filepath: str, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
     """Upload a file to S3 bucket
     :param filepath: Path to bee photo including filename
@@ -33,7 +39,7 @@ def upload_file(filepath: str, bucket: Optional[str] = None, acl: Optional[str] 
     s3_file_link = f"https://{s3_bucket}.s3.{aws_region}.amazonaws.com/{response.key}"
     print(s3_file_link)
 
-    return {"message":s3_file_link}
+    return s3_file_link
 
 @app.get("/bees/{file_path:path}")
 def fetch_bee_photo(file_path: str):

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ app = FastAPI()
 
 
 @app.post("/upload_bee/")
-def upload_bee_photo(file_obj:UploadFile(...), bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
+def upload_bee_photo(file_obj:UploadFile, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
     """
     Upload a bee photo to an S3 bucket
     - **file_obj**: required, a file like object - hopefully it is a nice bee photo
@@ -19,7 +19,7 @@ def upload_bee_photo(file_obj:UploadFile(...), bucket: Optional[str] = None, acl
     - **acl**: the S3 access control list type
     Returns the url of the file you uploaded
     """
-    s3_file_link = upload_file(file_obj=file, bucket=bucket, acl=acl)
+    s3_file_link = upload_file(file_obj=file_obj, bucket=bucket, acl=acl)
     return {"message":s3_file_link}
 
 def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:

--- a/main.py
+++ b/main.py
@@ -11,16 +11,23 @@ app = FastAPI()
 
 
 @app.post("/upload_bee/")
-def placeholder(file:UploadFile, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
+def upload_bee_photo(file_obj:UploadFile(...), bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
+    """
+    Upload a bee photo to an S3 bucket
+    - **file_obj**: required, a file like object - hopefully it is a nice bee photo
+    - **bucket**: the S3 bucket to post the file object to
+    - **acl**: the S3 access control list type
+    Returns the url of the file you uploaded
+    """
     s3_file_link = upload_file(file_obj=file, bucket=bucket, acl=acl)
     return {"message":s3_file_link}
 
 def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
-    """Upload a file to S3 bucket
-    :param filepath: Path to bee photo including filename
-    :param bucket: Bucket in s3 to upload to
-    :param acl: access control list value for the bucket in s3
-    :return: bucketname, path to file in bucket, and file name in bucket  if file uploaded, else False
+    """Upload a file like object to an S3 bucket
+    :param file_obj: File like object recognized by FastAPI
+    :param bucket: the S3 bucket to post the file object to
+    :param acl: the S3 access control list type
+    :return: dict containing a value with the URL of the file you uploaded
     """
     s3_bucket = bucket or os.environ["AWS_S3_BUCKET"]
 

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ load_dotenv()
 app = FastAPI()
 
 
-##TODO: Build out the fast api function placeholder so it is separate from the upload_file function
 @app.post("/upload_bee/")
 def placeholder():
     response.key = upload_file()
@@ -37,7 +36,6 @@ def upload_file(filepath: str, bucket: Optional[str] = None, acl: Optional[str] 
             Key=os.path.basename(filepath),Body=open(filepath,"rb"),ACL=acl
             )
     s3_file_link = f"https://{s3_bucket}.s3.{aws_region}.amazonaws.com/{response.key}"
-    print(s3_file_link)
 
     return s3_file_link
 

--- a/main.py
+++ b/main.py
@@ -19,8 +19,8 @@ def upload_bee_photo(file_obj:UploadFile, bucket: Optional[str] = None, acl: Opt
     - **acl**: the S3 access control list type
     Returns the url of the file you uploaded
     """
-    s3_file_link = upload_file(file_obj=file_obj, bucket=bucket, acl=acl)
-    return {"message":s3_file_link}
+    response = upload_file(file_obj=file_obj, bucket=bucket, acl=acl)
+    return {"message":response}
 
 def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = None) -> str:
     """Upload a file like object to an S3 bucket
@@ -40,10 +40,17 @@ def upload_file(file_obj, bucket: Optional[str] = None, acl: Optional[str] = Non
             aws_access_key_id = aws_key,
             aws_secret_access_key = aws_secret)
     
-    response = s3_client.upload_fileobj(file_obj.file, s3_bucket, file_obj.filename) 
+    response = s3_client.upload_fileobj(file_obj.file, s3_bucket, file_obj.filename)
+
     head = s3_client.head_object(Bucket = s3_bucket, Key = file_obj.filename)
-    success = head['ContentLength']
-    return success
+    upload_content_length = head['ContentLength']
+
+    if upload_content_length > 0:
+        response = f"https://{s3_bucket}.s3.{aws_region}.amazonaws.com/{file_obj.filename}"
+    else:
+        response = f"Something went wrong in upload_fileobj"
+
+    return response
 
 @app.get("/bees/{file_path:path}")
 def fetch_bee_photo(file_path: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pre-commit
 anyio==3.6.1
 asgiref==3.5.2
 boto3==1.24.45


### PR DESCRIPTION
This PR does the following:
- Take a file
- Upload it to the project S3 bucket
- On successful upload, return the file link as a response

I appreciate specific feedback on how I incorporated upload_fileobj in main.py. Using upload_fileobj, I was able to fully use the FastAPI file types and access attributes like filename. The more general upload_file example from the boto3 docs led to issues with pathing during development that upload_fileobj addressed. 

I am starting to think about longer upload times and failures. The head_object method a part of the s3_client in the upload_file function in main.py allows us to bring back metadata from a file that is actually in S3. Upload_fileobj didn't appear to actually return a response. The current implementation of upload_file in this PR uses the ContentLength key value from the file metadata to choose which response to return.

This may be overly complicated and unnecessary :bomb: but . . . I also learned a bunch of stuff :raccoon: Looking forward to moving onto the other routes.